### PR TITLE
chore: exporting validators from the library

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brightsoftware/date-np",
-  "version": "0.6.94",
+  "version": "0.6.95",
   "author": {
     "name": "bright office"
   },
@@ -31,6 +31,10 @@
       "import": "./dist/src/ui.js",
       "types": "./dist/types/src/ui.d.ts"
     },
+    "./validators": {
+      "import": "./dist/utils/validators.js",
+      "types": "./dist/types/utils/validators.d.ts"
+    },
     "./style.css": "./dist/style.css"
   },
   "main": "./dist/src/core.js",
@@ -59,18 +63,18 @@
   "devDependencies": {
     "@types/bun": "latest",
     "@vitest/ui": "^2.1.9",
-    "concurrently": "^9.1.2",
-    "react": "^19.1.0",
-    "typedoc": "^0.28.5",
-    "typedoc-plugin-markdown": "^4.6.4",
-    "vite": "^5.4.19",
+    "concurrently": "^9.2.1",
+    "react": "^19.2.3",
+    "typedoc": "^0.28.16",
+    "typedoc-plugin-markdown": "^4.9.0",
+    "vite": "^5.4.21",
     "vite-plugin-dts": "^4.5.4",
     "vitest": "^2.1.9",
-    "@tailwindcss/vite": "^4.1.8",
-    "@vitejs/plugin-react": "^4.5.1",
-    "tailwindcss": "^4.1.8",
-    "@types/react": "^19.1.0",
-    "@types/react-dom": "^19.1.0"
+    "@tailwindcss/vite": "^4.1.18",
+    "@vitejs/plugin-react": "^4.7.0",
+    "tailwindcss": "^4.1.18",
+    "@types/react": "^19.2.9",
+    "@types/react-dom": "^19.2.3"
   },
   "dependencies": {
     "clsx": "2.1.1",
@@ -79,6 +83,6 @@
   "license": "MIT",
   "peerDependencies": {
     "react": "17 || 18 || 19",
-    "react-dom": "17 || 18 || 19"
+    "react-dom": "^19.2.3"
   }
 }


### PR DESCRIPTION

Validators were not exported previously.

It is useful while using this package to have some internal validators such as validDateRange to be exported.
